### PR TITLE
[New Feature] Make use of Storage's backend instead of local filesystem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,19 @@ INSTALLED_APPS = [
     'migrations_mgmt_cmds',
     ...
 ]
+...
+# Inform the class' path that handle storage's backend
+MIGRATIONS_RELEASES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+...
 ```
+
 - Create a migration release
 ```sh
 python manage.py migrations_release --release v0.1
 ```
-- Check the release JSON file
+- Check the release JSON file in your storage backend
 ```sh
-ls migrations/releases/
+ls
 v0.1.json
 ```
 - Create a new migration
@@ -86,6 +91,12 @@ python manage.py showmigrations
 ```
 
 ## Important Notes
+
+### Storage's Backend
+
+The storage's backend to be used can be informed passing a class' path to the setting `MIGRATIONS_RELEASES_STORAGE`, in case it isn't informed, the value set-up at Django's setting `DEFAULT_FILE_STORAGE` will be used instead.
+
+You should inform the path as python package, e.g. `'path.Classname'`
 
 ### Known Issues
 

--- a/migrations_mgmt_cmds/management/commands/migrations_release.py
+++ b/migrations_mgmt_cmds/management/commands/migrations_release.py
@@ -55,8 +55,6 @@ class Command(BaseCommand):
 
             leaf_migrations[app_name] = graph.leaf_nodes(app_name)[0][1]
 
-        result = json.dumps(
-            leaf_migrations, sort_keys=True, indent=4, separators=(",", ": ")
-        )
+        result = json.dumps(leaf_migrations, sort_keys=True, indent=4, separators=(",", ": "))
 
         migrations_releases_storage.save(options["release"], result)

--- a/migrations_mgmt_cmds/management/commands/migrations_release.py
+++ b/migrations_mgmt_cmds/management/commands/migrations_release.py
@@ -56,10 +56,7 @@ class Command(BaseCommand):
             leaf_migrations[app_name] = graph.leaf_nodes(app_name)[0][1]
 
         result = json.dumps(
-            leaf_migrations,
-            sort_keys=True,
-            indent=4,
-            separators=(",", ": "),
+            leaf_migrations, sort_keys=True, indent=4, separators=(",", ": ")
         )
 
         migrations_releases_storage.save(options["release"], result)

--- a/migrations_mgmt_cmds/management/commands/migrations_release.py
+++ b/migrations_mgmt_cmds/management/commands/migrations_release.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import os
 import json
 
-from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.loader import MigrationLoader
+
+from migrations_mgmt_cmds.storage import migrations_releases_storage
 
 
 class Command(BaseCommand):
@@ -31,15 +31,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        if getattr(settings, "MIGRATIONS_RELEASES_DIR", None):
-            releases_dir = getattr(
-                settings,
-                "MIGRATIONS_RELEASES_DIR",
-                os.path.join(settings.BASE_DIR, "MIGRATIONS_RELEASES_DIR"),
-            )
-        else:
-            releases_dir = os.path.join(settings.BASE_DIR, "migrations/releases")
-
         db = options.get("database")
 
         # Load migration files from disk and their status from the database.
@@ -71,8 +62,4 @@ class Command(BaseCommand):
             separators=(",", ": "),
         )
 
-        if not os.path.exists(releases_dir):
-            os.makedirs(releases_dir)
-
-        with open(os.path.join(releases_dir, "{}.json".format(options["release"])), "w") as fp:
-            fp.write(result)
+        migrations_releases_storage.save(options["release"], result)

--- a/migrations_mgmt_cmds/management/commands/migrations_rollback.py
+++ b/migrations_mgmt_cmds/management/commands/migrations_rollback.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         if not migrations_releases_storage.exists(release_path):
             raise CommandError("No release file {!r}".format(release_path))
 
-        with migrations_releases_storage.open(release_path, 'r') as fp:
+        with migrations_releases_storage.open(release_path, "r") as fp:
             release = json.load(fp)
 
         targets = release.items()
@@ -90,7 +90,9 @@ class Command(BaseCommand):
         if self.verbosity >= 1:
             self.stdout.write(self.style.MIGRATE_HEADING("Operations to perform:"))
             for migration, applied in plan:
-                self.stdout.write("  Revert {} {}".format(migration.app_label, migration.name))
+                self.stdout.write(
+                    "  Revert {} {}".format(migration.app_label, migration.name)
+                )
 
         if self.verbosity >= 1:
             self.stdout.write(self.style.MIGRATE_HEADING("Running migrations:"))
@@ -106,7 +108,9 @@ class Command(BaseCommand):
                 self.stdout.write("  Applying %s..." % migration, ending="")
                 self.stdout.flush()
             elif action == "apply_success":
-                elapsed = " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
+                elapsed = (
+                    " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
+                )
                 if fake:
                     self.stdout.write(self.style.SUCCESS(" FAKED" + elapsed))
                 else:
@@ -117,7 +121,9 @@ class Command(BaseCommand):
                 self.stdout.write("  Unapplying %s..." % migration, ending="")
                 self.stdout.flush()
             elif action == "unapply_success":
-                elapsed = " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
+                elapsed = (
+                    " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
+                )
                 if fake:
                     self.stdout.write(self.style.SUCCESS(" FAKED" + elapsed))
                 else:
@@ -128,5 +134,7 @@ class Command(BaseCommand):
                 self.stdout.write("  Rendering model states...", ending="")
                 self.stdout.flush()
             elif action == "render_success":
-                elapsed = " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
+                elapsed = (
+                    " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
+                )
                 self.stdout.write(self.style.SUCCESS(" DONE" + elapsed))

--- a/migrations_mgmt_cmds/management/commands/migrations_rollback.py
+++ b/migrations_mgmt_cmds/management/commands/migrations_rollback.py
@@ -90,9 +90,7 @@ class Command(BaseCommand):
         if self.verbosity >= 1:
             self.stdout.write(self.style.MIGRATE_HEADING("Operations to perform:"))
             for migration, applied in plan:
-                self.stdout.write(
-                    "  Revert {} {}".format(migration.app_label, migration.name)
-                )
+                self.stdout.write("  Revert {} {}".format(migration.app_label, migration.name))
 
         if self.verbosity >= 1:
             self.stdout.write(self.style.MIGRATE_HEADING("Running migrations:"))
@@ -108,9 +106,7 @@ class Command(BaseCommand):
                 self.stdout.write("  Applying %s..." % migration, ending="")
                 self.stdout.flush()
             elif action == "apply_success":
-                elapsed = (
-                    " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
-                )
+                elapsed = " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
                 if fake:
                     self.stdout.write(self.style.SUCCESS(" FAKED" + elapsed))
                 else:
@@ -121,9 +117,7 @@ class Command(BaseCommand):
                 self.stdout.write("  Unapplying %s..." % migration, ending="")
                 self.stdout.flush()
             elif action == "unapply_success":
-                elapsed = (
-                    " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
-                )
+                elapsed = " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
                 if fake:
                     self.stdout.write(self.style.SUCCESS(" FAKED" + elapsed))
                 else:
@@ -134,7 +128,5 @@ class Command(BaseCommand):
                 self.stdout.write("  Rendering model states...", ending="")
                 self.stdout.flush()
             elif action == "render_success":
-                elapsed = (
-                    " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
-                )
+                elapsed = " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
                 self.stdout.write(self.style.SUCCESS(" DONE" + elapsed))

--- a/migrations_mgmt_cmds/management/commands/migrations_rollback.py
+++ b/migrations_mgmt_cmds/management/commands/migrations_rollback.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import os
 import json
 import time
 
-from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.executor import MigrationExecutor
+
+from migrations_mgmt_cmds.storage import migrations_releases_storage
 
 
 class Command(BaseCommand):
@@ -39,21 +39,14 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        if getattr(settings, "MIGRATIONS_RELEASES_DIR", None):
-            releases_dir = getattr(
-                settings,
-                "MIGRATIONS_RELEASES_DIR",
-                os.path.join(settings.BASE_DIR, "MIGRATIONS_RELEASES_DIR"),
-            )
-        else:
-            releases_dir = os.path.join(settings.BASE_DIR, "migrations/releases")
+        release_path = "{}.json".format(options["release"])
 
-        release_path = os.path.join(releases_dir, "{}.json".format(options["release"]))
-        if not os.path.exists(release_path):
+        if not migrations_releases_storage.exists(release_path):
             raise CommandError("No release file {!r}".format(release_path))
 
-        with open(release_path) as fp:
+        with migrations_releases_storage.open(release_path, 'r') as fp:
             release = json.load(fp)
+
         targets = release.items()
 
         self.verbosity = options.get("verbosity")

--- a/migrations_mgmt_cmds/storage.py
+++ b/migrations_mgmt_cmds/storage.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.utils.functional import LazyObject
+from django.core.files.storage import get_storage_class
+
+
+__all__ = [
+    'migrations_releases_storage'
+]
+
+
+class MigrationsReleasesStorage(LazyObject):
+    def _setup(self):
+        self._wrapped = get_storage_class(getattr(
+            settings,
+            "MIGRATIONS_RELEASES_STORAGE",
+            settings.DEFAULT_FILE_STORAGE
+        ))()
+
+
+migrations_releases_storage = MigrationsReleasesStorage()

--- a/migrations_mgmt_cmds/storage.py
+++ b/migrations_mgmt_cmds/storage.py
@@ -12,9 +12,7 @@ __all__ = ["migrations_releases_storage"]
 class MigrationsReleasesStorage(LazyObject):
     def _setup(self):
         self._wrapped = get_storage_class(
-            getattr(
-                settings, "MIGRATIONS_RELEASES_STORAGE", settings.DEFAULT_FILE_STORAGE
-            )
+            getattr(settings, "MIGRATIONS_RELEASES_STORAGE", settings.DEFAULT_FILE_STORAGE)
         )()
 
 

--- a/migrations_mgmt_cmds/storage.py
+++ b/migrations_mgmt_cmds/storage.py
@@ -6,18 +6,16 @@ from django.utils.functional import LazyObject
 from django.core.files.storage import get_storage_class
 
 
-__all__ = [
-    'migrations_releases_storage'
-]
+__all__ = ["migrations_releases_storage"]
 
 
 class MigrationsReleasesStorage(LazyObject):
     def _setup(self):
-        self._wrapped = get_storage_class(getattr(
-            settings,
-            "MIGRATIONS_RELEASES_STORAGE",
-            settings.DEFAULT_FILE_STORAGE
-        ))()
+        self._wrapped = get_storage_class(
+            getattr(
+                settings, "MIGRATIONS_RELEASES_STORAGE", settings.DEFAULT_FILE_STORAGE
+            )
+        )()
 
 
 migrations_releases_storage = MigrationsReleasesStorage()


### PR DESCRIPTION
## Description
This PR changes the code to make use of Storage's Backend instead of using local filesystem to save and open releases' files.

For it to work, a new setting is used and should be created in the project for specifying the backend's path: `MIGRATIONS_RELEASES_STORAGE`; defaulting to Django's `DEFAULT_FILE_STORAGE`.   

## Checklist

- [ ] All tests are passing
- [ ] New tests were created to address changes in pr (and tests are passing)
- [X] Updated README and/or documentation, if necessary
