### PR TITLE
[Fix] Change content to binary to avoid problems with MD5.

### DIFF
--- a/migrations_mgmt_cmds/management/commands/migrations_release.py
+++ b/migrations_mgmt_cmds/management/commands/migrations_release.py
@@ -7,7 +7,7 @@ from io import StringIO
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.loader import MigrationLoader
-from django.core.files import File
+from django.core.files.base import ContentFile
 
 from migrations_mgmt_cmds.storage import migrations_releases_storage
 
@@ -59,6 +59,8 @@ class Command(BaseCommand):
 
         result = json.dumps(leaf_migrations, sort_keys=True, indent=4, separators=(",", ": "))
 
-        file_object = File(StringIO(result), name=options["release"])
+        release_path = "{}.json".format(options["release"])
 
-        migrations_releases_storage.save(options["release"], file_object)
+        file_object = ContentFile(bytes(result, 'utf-8'), name=release_path)
+
+        migrations_releases_storage.save(release_path, file_object)

--- a/migrations_mgmt_cmds/management/commands/migrations_release.py
+++ b/migrations_mgmt_cmds/management/commands/migrations_release.py
@@ -61,6 +61,6 @@ class Command(BaseCommand):
 
         release_path = "{}.json".format(options["release"])
 
-        file_object = ContentFile(bytes(result, 'utf-8'), name=release_path)
+        file_object = ContentFile(bytes(result, "utf-8"), name=release_path)
 
         migrations_releases_storage.save(release_path, file_object)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-migrations-mgmt
-version = 0.2.2
+version = 0.2.3
 description = A Django management commands to help on migrations deployment rollbacks.
 url = https://github.com/italux/django-migrations-mgmt/
 author = Italo Santos


### PR DESCRIPTION
## Description

This PR change the encode of file being generate in memory to bytes, to allow backends like S3 to work properly when the backend make use of `generate_md5`.

Also fix a problem with extension .json not being create in filename.

Thanks for contributing!
