### PR TITLE
[HotFix] Change default sorting and add settings to allow users to inform its own method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ INSTALLED_APPS = [
 ...
 # Inform the class' path that handle storage's backend
 MIGRATIONS_RELEASES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+
+# Inform the function's path that handle storage's backend sorting method. 
+# This is optional and should be a called for parameter `key` of `sorted` function.  
+MIGRATIONS_RELEASES_SORTING = 'migrations_mgmt_cmds.management.commands.release_management.default_sort_date'
 ...
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-migrations-mgmt
-version = 0.3.1
+version = 0.3.2
 description = A Django management commands to help on migrations deployment rollbacks.
 url = https://github.com/italux/django-migrations-mgmt/
 author = Italo Santos


### PR DESCRIPTION
## Description
This PR change the default sorting to use created date and failing to use the modified date. And to avoid problem with this default, we also add the option for the developer pass its own function through setting `MIGRATIONS_RELEASES_SORTING`. 

This new setting is optional and if absent the function `default_sort_date` will be used instead.

## Checklist

- [ ] All tests are passing
- [ ] New tests were created to address changes in pr (and tests are passing)
- [ ] Updated README and/or documentation, if necessary

Thanks for contributing!
